### PR TITLE
provide: Clone 'this' without touching the object prototype

### DIFF
--- a/src/provide.js
+++ b/src/provide.js
@@ -275,7 +275,13 @@ export default function provide(ComponentClass) {
         this.getQueryResults(props, context);
         this.getPartialStates(props, context);
         this.getSubscriptions(props, context);
-        this.fauxInstance = { ...this, props: componentProps };
+        this.fauxInstance = {
+          ...Object.getOwnPropertyNames(this).reduce(
+            (prev, propName) => ({ ...prev, [propName]: this[propName] }),
+            {}
+          ),
+          props: componentProps
+        };
       }
 
       this.fauxInstance.context = context;


### PR DESCRIPTION
Hi @timbur!

I have recently started a project in React Native and I wanted to use `react-redux-provide` for state handling, to avoid all the boilerplate involved in `react-redux`.

I ran into an issue though:

<img width="375" alt="screen shot 2017-08-27 at 08 56 42" src="https://user-images.githubusercontent.com/6997051/29747810-23497292-8b06-11e7-9be6-a72bcd927d0d.png">

As the message states, this happens when the `fauxInstance` is being created by cloning the provided wrapper component (?) and merging in the component props.

My patch was to adjust the cloning code so it only copies enumerable properties and leaves the prototype behind. I am not sure this is the best approach, but my application is running without errors now and I can get back to application development.

Could there be some edge case where the prototype would need to be cloned to the `fauxInstance` as well, or would utilisation of the prototype be an anti-pattern altogether?
What are your thoughts?

By the way, it is great to see that this project is still evolving after having been away for it for a while! Great job! 🎉 